### PR TITLE
Add scripts used to remove unused mappigns

### DIFF
--- a/bin/ip-wrangler-clean.sh
+++ b/bin/ip-wrangler-clean.sh
@@ -1,18 +1,64 @@
 #!/bin/bash
 
-if [ -z "$1" ]
+# It removes iptables rules, created by Ip-Wrangler, which are NAT to nowhere.
+
+usage() { echo "Usage: $(basename $0) -n(ova_list) <path/to/file/with/nova_list.dump> -U(ser IpWrangler) <user> -P(assword IpWrangler) <password> -u(rl IpWrangler) <URL|maybe:http://127.0.0.1:8400> -p(refix) <IpPrefix|maybe:192.168.0>" 1>&2; exit 0; }
+
+while getopts ":n:U:P:u:p:" __opts; do
+    case "${__opts}" in
+        n)
+            export nova_list_path=${OPTARG}
+            ;;
+        U)
+            export user=${OPTARG}
+            ;;
+        P)
+            export password=${OPTARG}
+            ;;
+        u)
+            export url=${OPTARG}
+            ;;
+        p)
+            export prefix=${OPTARG}
+            ;;
+        h)
+            usage
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+if [ -z "${nova_list_path}" ] || [ -z "${user}" ] || [ -z "${password}" ] || [ -z "${url}" ] || [ -z "${prefix}" ]
 then
-    echo "Usage: $(basename $0) <iptables_chain_name|maybe:IPT_WR>"
-    exit 1
+    usage
 fi
 
-iptables_chain_name=$1
+nova_list=$(cat ${nova_list_path})
+for ppp in $(for pp in $(curl -u ${user}:${password} ${url}/dnat | sed 's/\",\"/ /g' | sed 's/\[\"//g' | sed 's/\"\]//g')
+do
+    echo ${pp}
+done | sort | uniq | grep ${prefix})
+do
+    echo "${ppp} --->"
+    echo "${nova_list}" | grep "${ppp} "
 
-set -x
-
-sudo /sbin/iptables -t nat --delete PREROUTING --jump ${iptables_chain_name}_PRE
-sudo /sbin/iptables -t nat --delete POSTROUTING --jump ${iptables_chain_name}_POST
-sudo /sbin/iptables -t nat --flush ${iptables_chain_name}_PRE
-sudo /sbin/iptables -t nat --flush ${iptables_chain_name}_POST
-sudo /sbin/iptables -t nat --delete-chain ${iptables_chain_name}_PRE
-sudo /sbin/iptables -t nat --delete-chain ${iptables_chain_name}_POST
+    is_vm=$(echo "${nova_list}" | grep "${ppp} " | wc -l)
+    if [ ${is_vm} == 0 ]
+    then
+        echo "VM not exists!"
+        __output=$(nmap ${ppp} | grep down)
+        echo ${__output}
+        is_vm_down=$(echo "${__output}" | wc -l)
+        if [ ${is_vm_down} == 1 ]
+        then
+            echo "Do you want to delete this IP: ${ppp}? Answer \"yes\": "
+            read answer
+            if [ "${answer}" == "yes" ]
+            then
+                curl -u ${user}:${password} -X DELETE --data "" ${url}/dnat/${ppp}
+            fi
+        fi
+    fi
+done

--- a/bin/ip-wrangler-clean.sh
+++ b/bin/ip-wrangler-clean.sh
@@ -2,6 +2,8 @@
 
 # It removes iptables rules, created by Ip-Wrangler, which are NAT to nowhere.
 
+echo "NO WARRANTY. YOU ARE USING THIS ON YOUR OWN RISK!"
+
 command -v curl > /dev/null 2>&1 || { echo "No 'curl'" >&2; exit 1; }
 command -v nmap > /dev/null 2>&1 || { echo "No 'nmap'" >&2; exit 1; }
 
@@ -37,6 +39,9 @@ if [ -z "${nova_list_path}" ] || [ -z "${user}" ] || [ -z "${password}" ] || [ -
 then
     usage
 fi
+
+echo "You can interrupt it now by (ctrl)+(c).."
+read
 
 nova_list=$(cat ${nova_list_path})
 for ppp in $(for pp in $(curl -u ${user}:${password} ${url}/dnat | sed 's/\",\"/ /g' | sed 's/\[\"//g' | sed 's/\"\]//g')

--- a/bin/ip-wrangler-clean.sh
+++ b/bin/ip-wrangler-clean.sh
@@ -2,6 +2,9 @@
 
 # It removes iptables rules, created by Ip-Wrangler, which are NAT to nowhere.
 
+command -v curl > /dev/null 2>&1 || { echo "No 'curl'" >&2; exit 1; }
+command -v nmap > /dev/null 2>&1 || { echo "No 'nmap'" >&2; exit 1; }
+
 usage() { echo "Usage: $(basename $0) -n(ova_list) <path/to/file/with/nova_list.dump> -U(ser IpWrangler) <user> -P(assword IpWrangler) <password> -u(rl IpWrangler) <URL|maybe:http://127.0.0.1:8400> -p(refix) <IpPrefix|maybe:192.168.0>" 1>&2; exit 0; }
 
 while getopts ":n:U:P:u:p:" __opts; do

--- a/bin/ip-wrangler-purge
+++ b/bin/ip-wrangler-purge
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+name = 'ip-wrangler'
+gem = Gem::Specification.find_by_name(name)
+command = File.join(gem.full_gem_path, 'bin/ip-wrangler-purge.sh')
+system(command, *ARGV)

--- a/bin/ip-wrangler-purge.sh
+++ b/bin/ip-wrangler-purge.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+then
+    echo "Usage: $(basename $0) <iptables_chain_name|maybe:IPT_WR>"
+    exit 1
+fi
+
+iptables_chain_name=$1
+
+set -x
+
+sudo /sbin/iptables -t nat --delete PREROUTING --jump ${iptables_chain_name}_PRE
+sudo /sbin/iptables -t nat --delete POSTROUTING --jump ${iptables_chain_name}_POST
+sudo /sbin/iptables -t nat --flush ${iptables_chain_name}_PRE
+sudo /sbin/iptables -t nat --flush ${iptables_chain_name}_POST
+sudo /sbin/iptables -t nat --delete-chain ${iptables_chain_name}_PRE
+sudo /sbin/iptables -t nat --delete-chain ${iptables_chain_name}_POST

--- a/bin/ip-wrangler-purge.sh
+++ b/bin/ip-wrangler-purge.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
+# It removes iptables chains, created by Ip-Wrangler.
+
+echo "NO WARRANTY. YOU ARE USING THIS ON YOUR OWN RISK!"
+
 if [ -z "$1" ]
 then
     echo "Usage: $(basename $0) <iptables_chain_name|maybe:IPT_WR>"
     exit 1
 fi
+
+echo "You can interrupt it now by (ctrl)+(c).."
+read
 
 iptables_chain_name=$1
 

--- a/bin/ip-wrangler-test.sh
+++ b/bin/ip-wrangler-test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# It provides execution tests for Ip-Wrangler.
+
+echo "NO WARRANTY. YOU ARE USING THIS ON YOUR OWN RISK!"
+
 #set -x
 
 export __IP="127.0.0.1"
@@ -24,10 +28,15 @@ if (( "$#" >= "4" )); then
     export __PASS=$4
 fi
 
-echo "${__IP} ${__PORT} ${__USER} ${__PASS}"
+echo "IP: ${__IP} Port:${__PORT} User:${__USER} Pass:${__PASS}"
 
+echo "You can interrupt it now by (ctrl)+(c).."
 read
 
+echo "Press enter to continue.."
+read
+
+echo "Add tcp/udp port NAT rules using new API"
 for __ip in `seq 1 3`; do
     for __port in `seq 1000 1010`; do
         curl -u ${__USER}:${__PASS} -X POST --data "" http://${__IP}:${__PORT}/nat/port/127.0.0.${__ip}/${__ip}${__port}/tcp
@@ -37,8 +46,10 @@ for __ip in `seq 1 3`; do
     done
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Add port NAT rules using new API"
 for __ip in `seq 1 3`; do
     for __port in `seq 1005 1015`; do
         curl -u ${__USER}:${__PASS} -X POST --data "" http://${__IP}:${__PORT}/nat/port/127.0.0.${__ip}/${__ip}${__port}
@@ -46,28 +57,36 @@ for __ip in `seq 1 3`; do
     done
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Add IP NAT rules using new API"
 for __ip in `seq 1 3`; do
     curl -u ${__USER}:${__PASS} -X POST --data "" http://${__IP}:${__PORT}/nat/ip/127.0.1.${__ip}
     echo ""
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Print all port NAT rules"
 curl -u ${__USER}:${__PASS} http://${__IP}:${__PORT}/nat/port
 echo ""
 
+echo "Print all port NAT rules for specific IP"
 for __ip in `seq 1 3`; do
     curl -u ${__USER}:${__PASS} http://${__IP}:${__PORT}/nat/port/127.0.0.${__ip}
     echo ""
 done
 
+echo "Print all IP rules"
 curl -u ${__USER}:${__PASS} http://${__IP}:${__PORT}/nat/ip
 echo ""
 
+echo "Press enter to continue.."
 read
 
+echo "Remove tcp/udp port NAT rules using new API"
 for __ip in `seq 1 3`; do
     for __port in `seq 1000 1010`; do
         curl -u ${__USER}:${__PASS} -X DELETE --data "" http://${__IP}:${__PORT}/nat/port/127.0.0.${__ip}/${__ip}${__port}/tcp
@@ -77,8 +96,10 @@ for __ip in `seq 1 3`; do
     done
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Remove port NAT rules using new API"
 for __ip in `seq 1 3`; do
     for __port in `seq 1005 1015`; do
         curl -u ${__USER}:${__PASS} -X DELETE --data "" http://${__IP}:${__PORT}/nat/port/127.0.0.${__ip}/${__ip}${__port}
@@ -86,30 +107,39 @@ for __ip in `seq 1 3`; do
     done
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Remove port NAT rules per IP using new API"
 for __ip in `seq 1 3`; do
     curl -u ${__USER}:${__PASS} -X DELETE --data "" http://${__IP}:${__PORT}/nat/port/127.0.0.${__ip}
     echo ""
 done
 
+echo "Remove IP NAT rules per IP using new API"
 for __id in `seq 1 2`; do
     curl -u ${__USER}:${__PASS} -X DELETE --data "" http://${__IP}:${__PORT}/nat/ip/127.0.1.${__id}
     echo ""
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Remove IP NAT rules per IP using new API (again)"
 curl -u ${__USER}:${__PASS} -X DELETE --data "" http://${__IP}:${__PORT}/nat/ip/127.0.1.3
 echo ""
 
+echo "Press enter to continue.."
 read
 
+echo "Echo test"
 curl -u ${__USER}:${__PASS} http://${__IP}:${__PORT}/
 echo ""
 
+echo "Press enter to continue.."
 read
 
+echo "Add tcp/udp port NAT rules using old API"
 for __ip in `seq 1 3`; do
     for __port in `seq 1000 1010`; do
         curl -u ${__USER}:${__PASS} -X POST --data "[{\"port\": ${__ip}${__port}, \"proto\": \"tcp\"}]" http://${__IP}:${__PORT}/dnat/127.0.0.${__ip}
@@ -119,8 +149,10 @@ for __ip in `seq 1 3`; do
     done
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Add tcp/udp port NAT rules using old API"
 for __ip in `seq 1 3`; do
     for __port in `seq 1005 1015`; do
         curl -u ${__USER}:${__PASS} -X POST --data "[{\"port\": ${__ip}${__port}, \"proto\": \"tcp\"}, {\"port\": ${__ip}${__port}, \"proto\": \"udp\"}]" http://${__IP}:${__PORT}/dnat/127.0.0.${__ip}
@@ -128,18 +160,23 @@ for __ip in `seq 1 3`; do
     done
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Print all port NAT rules"
 curl -u ${__USER}:${__PASS} http://${__IP}:${__PORT}/dnat
 echo ""
 
+echo "Print all port NAT rules for specific IP"
 for __ip in `seq 1 3`; do
     curl -u ${__USER}:${__PASS} http://${__IP}:${__PORT}/dnat/127.0.0.${__ip}
     echo ""
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Remove tcp/udp port NAT rules using old API"
 for __ip in `seq 1 3`; do
     for __port in `seq 1000 1010`; do
         curl -u ${__USER}:${__PASS} -X DELETE --data "" http://${__IP}:${__PORT}/dnat/127.0.0.${__ip}/${__ip}${__port}/tcp
@@ -149,8 +186,10 @@ for __ip in `seq 1 3`; do
     done
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Remove port NAT rules using old API"
 for __ip in `seq 1 3`; do
     for __port in `seq 1005 1015`; do
         curl -u ${__USER}:${__PASS} -X DELETE --data "" http://${__IP}:${__PORT}/dnat/127.0.0.${__ip}/${__ip}${__port}
@@ -158,8 +197,10 @@ for __ip in `seq 1 3`; do
     done
 done
 
+echo "Press enter to continue.."
 read
 
+echo "Remove port NAT rules using old API (again)"
 for __ip in `seq 1 3`; do
     curl -u ${__USER}:${__PASS} -X DELETE --data "" http://${__IP}:${__PORT}/nat/port/127.0.0.${__ip}
     echo ""


### PR DESCRIPTION
@dice-cyfronet/atmo-dev-team, @tbartynski, @jmeizner take a look. It provides a mechanism to removing _iptables_ rules from `IPT_WR` chains and _ip-wrangler_ database if rules NAT to nowhere (VM not exists).
